### PR TITLE
set the blob to the _src property before play so that it will not be …

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,8 @@ export default class DashShakaPlayback extends HTML5Video {
       this.once(SHAKA_READY, this.play)
       return
     }
+
+    this._src = this.el.src;
     super.play()
   }
 
@@ -99,7 +101,6 @@ export default class DashShakaPlayback extends HTML5Video {
     this._isShakaReadyState = false
     this._player = this._createPlayer()
     this._options.shakaConfiguration && this._player.configure(this._options.shakaConfiguration)
-
     var playerLoaded = this._player.load(this._options.src)
     playerLoaded.then(() => this._loaded())
       .catch((e) => this._setupError(e))


### PR DESCRIPTION
Before play, the blob url will be set to the video player. But in the super's play function, the video's url will be set as this._src which is the original dash url. Then the play of the video will be failed.
I am using the latest shaka lib.