### PR TITLE
Add Shaka License Wrapping option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ A [clappr](https://github.com/clappr/clappr) playback to play dash based on [sha
             streaming: {
               rebufferingGoal: 15
             }
-          }
+          },
+          shakaOnBeforeLoad: function(shaka_player) {
+            // shaka_player.getNetworkingEngine().registerRequestFilter() ...
+          },
           parentId: '#player'
         });
     </script>
@@ -45,6 +48,10 @@ A [clappr](https://github.com/clappr/clappr) playback to play dash based on [sha
 # DRM
 
 If need to protect your content (DRM) you must use the `shakaConfiguration` following the [shaka configuration](http://shaka-player-demo.appspot.com/docs/api/tutorial-drm-config.html) need.
+
+# License Wrapping
+
+If need to wrap DRM license requests or responses you use `shakaOnBeforeLoad` following [shaka License Wrapping](http://shaka-player-demo.appspot.com/docs/api/tutorial-license-wrapping.html) guide.
 
 # Development
 

--- a/index.js
+++ b/index.js
@@ -101,6 +101,8 @@ export default class DashShakaPlayback extends HTML5Video {
     this._isShakaReadyState = false
     this._player = this._createPlayer()
     this._options.shakaConfiguration && this._player.configure(this._options.shakaConfiguration)
+    this._options.shakaOnBeforeLoad && this._options.shakaOnBeforeLoad(this._player)
+
     var playerLoaded = this._player.load(this._options.src)
     playerLoaded.then(() => this._loaded())
       .catch((e) => this._setupError(e))

--- a/public/index.html
+++ b/public/index.html
@@ -1,31 +1,51 @@
-<!DOCTYPE HTML>
+﻿<!DOCTYPE HTML>
 <html>
-  <head>
+<head>
     <meta charset="utf-8">
     <title>clappr dash shaka</title>
-  </head>
-  <body>
+</head>
+<body>
     <div id="player"></div>
     <script type="text/javascript" charset="utf-8">
-      window.onload = function() {
-        var player = new Clappr.Player({
-          parentId: '#player',autoPlay:true,
-          plugins: [DashShakaPlayback, LevelSelector],
-          //source: 'http://live.unified-streaming.com/loop/loop.isml/loop.mpd?format=mp4&session_id=25020', //LIVE
-          source: '//storage.googleapis.com/shaka-demo-assets/angel-one/dash.mpd', //multi audio, sub
-          //source: 'http://dash.edgesuite.net/dash264/TestCases/2c/qualcomm/2/MultiRes.mpd', //VOD multiple qualities
-          //source: 'http://rdmedia.bbc.co.uk/dash/ondemand/elephants_dream/1/client_manifest-all.mpd', //SUB
-          //source: 'http://dash.edgesuite.net/dash264/TestCases/3b/fraunhofer/heaac_stereo_with_video/ElephantsDream/elephants_dream_480p_heaac_stereo_sidx.mpd', //VOD multiple audios
-          //source: 'http://dash.edgesuite.net/dash264/TestCases/4b/qualcomm/2/TearsOfSteel_onDem5secSegSubTitles.mpd', //VOD subtitle
-          //source: 'http://dash.edgesuite.net/akamai/streamroot/050714/Spring_4Ktest.mpd', //4K
-          // for more examples go to: http://dashif.org/reference/players/javascript/v1.5.1/samples/dash-if-reference-player/index.html and https://shaka-player-demo.appspot.com/
-          height: 360,
-          width: 640
-        })
-      }
+        window.onload = function () {
+            var onBeforeLoad = function (shaka_player) {
+                shaka_player.getNetworkingEngine().registerRequestFilter(function (type, request) {
+                    if (type == 2) { // shaka.net.NetworkingEngine.RequestType.LICENSE
+                        // do something
+                    }
+                });
+                shaka_player.getNetworkingEngine().registerResponseFilter(function (type, response) {
+                    if (type == 2) { // shaka.net.NetworkingEngine.RequestType.LICENSE
+                        // do something
+                    }
+                });
+            }
+
+            var player = new Clappr.Player({
+                parentId: '#player', autoPlay: true,
+                plugins: [DashShakaPlayback, LevelSelector],
+                shakaConfiguration: {
+                    preferredAudioLanguage: 'pt-BR',
+                    streaming: {
+                        rebufferingGoal: 15
+                    }
+                },
+                shakaOnBeforeLoad: onBeforeLoad,
+                //source: 'http://live.unified-streaming.com/loop/loop.isml/loop.mpd?format=mp4&session_id=25020', //LIVE
+                source: '//storage.googleapis.com/shaka-demo-assets/angel-one/dash.mpd', //multi audio, sub
+                //source: 'http://dash.edgesuite.net/dash264/TestCases/2c/qualcomm/2/MultiRes.mpd', //VOD multiple qualities
+                //source: 'http://rdmedia.bbc.co.uk/dash/ondemand/elephants_dream/1/client_manifest-all.mpd', //SUB
+                //source: 'http://dash.edgesuite.net/dash264/TestCases/3b/fraunhofer/heaac_stereo_with_video/ElephantsDream/elephants_dream_480p_heaac_stereo_sidx.mpd', //VOD multiple audios
+                //source: 'http://dash.edgesuite.net/dash264/TestCases/4b/qualcomm/2/TearsOfSteel_onDem5secSegSubTitles.mpd', //VOD subtitle
+                //source: 'http://dash.edgesuite.net/akamai/streamroot/050714/Spring_4Ktest.mpd', //4K
+                // for more examples go to: http://dashif.org/reference/players/javascript/v1.5.1/samples/dash-if-reference-player/index.html and https://shaka-player-demo.appspot.com/
+                height: 360,
+                width: 640
+            })
+        }
     </script>
     <script src="https://cdn.jsdelivr.net/clappr/latest/clappr.min.js"></script>
     <script type="text/javascript" charset="utf-8" src="./dash-shaka-playback.js"> </script>
     <script type="text/javascript" src="//cdn.jsdelivr.net/clappr.level-selector/latest/level-selector.min.js"></script>
-  </body>
+</body>
 </html>


### PR DESCRIPTION
Currently there is no way to wrap license requests and responses in the Shaka way.
I added the option to do so, and updated the sample and README.
Thanks