### PR TITLE
[WIP] Shaka external bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,16 +8,19 @@
     "url": "git@github.com:clappr/dash-shaka-playback.git"
   },
   "scripts": {
-    "build": "node_modules/.bin/webpack",
-    "start": "node_modules/.bin/webpack-dev-server --host 0.0.0.0 --content-base public/ --hot",
-    "release": "node_modules/.bin/webpack",
-    "lint": "node_modules/.bin/eslint index.js"
+    "build": "webpack",
+    "dist": "npm run lint && npm run build && npm run release",
+    "start": "webpack-dev-server",
+    "release": "webpack",
+    "lint": "eslint index.js"
   },
   "author": "Clappr team",
   "license": "BSD-3-Clause",
   "devDependencies": {
-    "babel-core": "^5.8.25",
-    "babel-loader": "^5.3.2",
+    "babel-core": "^6.25.0",
+    "babel-loader": "^7.1.1",
+    "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-preset-es2015": "^6.24.1",
     "clappr": "^0.2.66",
     "eslint": "^4.2.0",
     "eslint-config-standard": "^10.2.1",
@@ -26,7 +29,7 @@
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
     "shaka-player": "2.1.4",
-    "webpack": "^1.12.1",
-    "webpack-dev-server": "^1.10.1"
+    "webpack": "^3.0.0",
+    "webpack-dev-server": "^2.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,19 +15,17 @@
   },
   "author": "Clappr team",
   "license": "BSD-3-Clause",
-  "dependencies": {
-    "shaka-player": "2.1.4",
-    "clappr": "0.2.66"
-  },
   "devDependencies": {
     "babel-core": "^5.8.25",
     "babel-loader": "^5.3.2",
-    "eslint": "^3.19.0",
+    "clappr": "^0.2.66",
+    "eslint": "^4.2.0",
     "eslint-config-standard": "^10.2.1",
-    "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-node": "^4.2.2",
+    "eslint-plugin-import": "^2.3.0",
+    "eslint-plugin-node": "^5.1.0",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
+    "shaka-player": "2.1.4",
     "webpack": "^1.12.1",
     "webpack-dev-server": "^1.10.1"
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,63 +1,100 @@
-var path = require('path');
-var webpack = require('webpack');
+const path = require('path')
+const webpack = require('webpack')
 
-var ENTRY_POINT = 'src/clappr-dash-shaka-playback.js'
+var NPM_RUN = process.env.npm_lifecycle_event
 
-module.exports = [
-  {
-    devtool: 'source-maps',
-    entry: path.resolve(__dirname, ENTRY_POINT),
-    externals: {
-      "clappr": 'Clappr',
-      "shaka-player": 'shaka'
+const externals = () => {
+  // By default, only Clappr is defined as external library
+  return {
+    clappr: {
+      amd: 'clappr',
+      commonjs: 'clappr',
+      commonjs2: 'clappr',
+      root: 'Clappr'
+    }
+  }
+}
+
+const webpackConfig = (config) => {
+  return {
+    devServer: {
+      contentBase: [
+        path.resolve(__dirname, 'public'),
+      ],
+      disableHostCheck: true, // https://github.com/webpack/webpack-dev-server/issues/882
+      compress: true,
+      host: '0.0.0.0',
+      port: 8080
     },
+    devtool: 'source-maps',
+    entry: path.resolve(__dirname, 'src/clappr-dash-shaka-playback.js'),
+    externals: config.externals,
     module: {
-      loaders: [
+      rules: [
         {
           test: /\.js$/,
-          loader: 'babel'
-        }
+          loader: 'babel-loader',
+          include: [
+            path.resolve(__dirname, 'src')
+          ],
+          options: {
+            presets: ['es2015'],
+            plugins: ['add-module-exports'],
+          },
+        },
       ],
     },
-    resolve: {
-      extensions: ['', '.js'],
-    },
     output: {
-      filename: 'dash-shaka-playback.js',
+      filename: config.filename,
       library: 'DashShakaPlayback',
       libraryTarget: 'umd',
     },
-  },
+    plugins: config.plugins,
+  }
+}
 
-  {
-    devtool: 'source-maps',
-    entry: path.resolve(__dirname, ENTRY_POINT),
-    externals: {
-      "clappr": 'Clappr',
-      "shaka-player": 'shaka'
-    },
-    module: {
-      loaders: [
-        {
-          test: /\.js$/,
-          loader: 'babel'
-        }
-      ],
-    },
-    resolve: {
-      extensions: ['', '.js'],
-    },
-    output: {
-      filename: 'dash-shaka-playback.min.js',
-      library: 'DashShakaPlayback',
-      libraryTarget: 'umd',
-    },
+var configurations = []
+
+if (NPM_RUN === 'build' || NPM_RUN === 'start') {
+  // Unminified bundle with shaka-player
+  configurations.push(webpackConfig({
+    filename: 'dash-shaka-playback.js',
+    plugins: [],
+    externals: externals()
+  }))
+}
+
+if (NPM_RUN === 'release') {
+  // Minified bundle with shaka-player
+  configurations.push(webpackConfig({
+    filename: 'dash-shaka-playback.min.js',
     plugins: [
       new webpack.optimize.UglifyJsPlugin({
         compress: {
           warnings: false
-        }
+        },
+        sourceMap: true
       }),
-    ]
-  }
-];
+    ],
+    externals: externals()
+  }))
+
+  // Minified bundle without shaka-player
+  var customExt = externals()
+  customExt['shaka-player'] = 'shaka'
+  configurations.push(webpackConfig({
+    filename: 'dash-shaka-playback-external.min.js',
+    plugins: [
+      new webpack.optimize.UglifyJsPlugin({
+        compress: {
+          warnings: false
+        },
+        sourceMap: true
+      }),
+    ],
+    externals: customExt
+  }))
+}
+
+// https://webpack.js.org/configuration/configuration-types/#exporting-multiple-configurations
+module.exports = configurations


### PR DESCRIPTION
Should satisfy #28.

It upgrade Eslint, Webpack and Babel to latest releases.

It introduce a new minified bundle `dash-shaka-playback-external.min.js` which is compiled with shaka-player as external library.

I updated the Webpack configuration to restore the compilation behaviour from 2.0.7 tag (_ie: `npm run build` to build unminified bundle, and `npm run release` to build minified bundles_) and i added a `npm run dist` shortcut task to run lint + build + release npm tasks.

I am open to any suggestions or modifications 😸 

PS: please note this PR does NOT modify dist bundle files. (_and imho should not !_)
