### PR TITLE
Enable shaka in hls source videos

### DIFF
--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -15,7 +15,7 @@ class DashShakaPlayback extends HTML5Video {
     shaka.polyfill.installAll()
     var browserSupported = shaka.Player.isBrowserSupported()
     var resourceParts = resource.split('?')[0].match(/.*\.(.*)$/) || []
-    return browserSupported && ((resourceParts[1] === 'mpd') || mimeType.indexOf('application/dash+xml') > -1)
+    return browserSupported && ((resourceParts[1] === 'mpd') || mimeType.indexOf('application/dash+xml') > -1 || (resourceParts[1] === 'm3u8') )
   }
 
   get name () {


### PR DESCRIPTION
I  am using shaka to play my videos, but some of them are hls format, with m3u8 extension. All segments are downloaded without respect buffer by default handler in clappr . Fix canPlay to handle m3u8 files