### PR TITLE
Send stats & level-switch-end onAdaptation 

### DIFF
--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -298,7 +298,7 @@ class DashShakaPlayback extends HTML5Video {
     
     if (this._pendingAdaptationEvent_) {
       this.trigger(Events.PLAYBACK_LEVEL_SWITCH_END)
-      this._pendingAdaptationEvent_ = false
+      this._pendingAdaptationEvent = false
     }
     
     Log.debug('an adaptation has happened:', activeVideo)

--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -41,7 +41,7 @@ class DashShakaPlayback extends HTML5Video {
     this.trigger(Events.PLAYBACK_LEVEL_SWITCH_START)
     if (!isAuto) {
       this._player.configure({abr: {enabled: false}})
-      this._pendingAdaptationEvent = true;
+      this._pendingAdaptationEvent = true
       this.selectTrack(this.videoTracks.filter((t) => t.id === this._currentLevelId)[0])
     }
     else {


### PR DESCRIPTION
* Send stats before triggering level-switch-end & bitrate events. 
* Trigger level-switch-end only once the Shaka adaptation event happened

- We need to update stats that may have changed before we trigger event so that user can rely on stats data when handling event
- Instead of triggering two events (level-switch-start/end) in the same tick, we would like to have the end event after Shaka has actually triggered adaptation (Shaka switch likely being async), or at least after being sure Shaka has updated its datamodel.