### PR TITLE
Fixing errors on stop/destroy

### DIFF
--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -217,14 +217,14 @@ class DashShakaPlayback extends HTML5Video {
     clearInterval(this.sendStatsId)
 
     if (this._player) {
-      this._destroy()
-    } else {
       this._player.destroy()
         .then(() => this._destroy())
         .catch(() => {
           this._destroy()
           Log.error('shaka could not be destroyed')
         })
+    } else {
+      this._destroy()
     }
   }
 

--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -97,15 +97,20 @@ class DashShakaPlayback extends HTML5Video {
 
   stop () {
     clearInterval(this.sendStatsId)
-    this._sendStats()
 
-    this._player.unload().then(() => {
+    if (this._player) {
+      this._sendStats()
+
+      this._player.unload().then(() => {
+        super.stop()
+        this._player = null
+        this._isShakaReadyState = false
+      }).catch(() => {
+        Log.error('shaka could not be unloaded')
+      })
+    } else {
       super.stop()
-      this._player = null
-      this._isShakaReadyState = false
-    }).catch(() => {
-      Log.error('shaka could not be unloaded')
-    })
+    }
   }
 
   get textTracks () {


### PR DESCRIPTION
**Stop method**: In some cases the stop method can be called before creating Shaka player instance, in this case, _getStats_ and _unload_ methods should not be called.

**Destroy method**: The if/else logic was inverted, and Shaka player's destroy method was being called if the instance did not exist, causing errors.
