### PR TITLE
Fixing Shaka Player API usage: With shaka 2.2.x the `selectTrack` method was removed

### DIFF
--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -136,8 +136,18 @@ class DashShakaPlayback extends HTML5Video {
   }
 
   selectTrack (track) {
-    this._player.selectTrack(track)
-    this._onAdaptation()
+    if (track.type === 'text') {
+        this._player.selectTextTrack(track)
+    } else if (track.type === 'variant') {
+        this._player.selectVariantTrack(track)
+        if (track.mimeType.startsWith('video/')) {
+            // we trigger the adaptation event here
+            // because Shaka doesn't trigger its event on "manual" selection.
+            this._onAdaptation()
+        }
+    } else {
+        throw new Error('Unhandled track type:', track.type);
+    }
   }
 
   /**


### PR DESCRIPTION
It had been deprecated and now is gone. 

This means currently the plugin is seriously broken as selectTrack wont work :)

Here is the fix:

- For text type tracks we now use selectTextTrack
- For variant type tracks we now use selectVariantTrack
- In case the track type is unknown (should Shaka Track object type values be extended) we throw an error
- We only trigger manual adpatation events when the track mime-type is video/ something