### PR TITLE
Fix for Shaka 2.2.x to be able to switch languages

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+indent_style = space
+indent_size = 2
+
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[{package.json}]
+indent_style = space
+indent_size = 2

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "dist": "yarn lint && yarn build && yarn release",
     "start": "webpack-dev-server",
     "release": "webpack",
-    "lint": "eslint index.js"
+    "lint": "eslint src index.js",
+    "lint:fix": "eslint src index.js --fix"
   },
   "author": "Clappr team",
   "license": "BSD-3-Clause",

--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -124,6 +124,15 @@ class DashShakaPlayback extends HTML5Video {
     }
   }
 
+  /**
+  * Determine if the playback does not contain video/has video but video should be ignored.
+  * @property isAudioOnly
+  * @type Boolean
+  */
+  get isAudioOnly() {
+    return this.isReady ? this._player.isAudioOnly() : false
+  }
+
   get textTracks () {
     return this.isReady && this._player.getTextTracks()
   }

--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -149,19 +149,30 @@ class DashShakaPlayback extends HTML5Video {
     return (this.isReady && this._player.isLive() ? 'live' : 'vod') || ''
   }
 
-  selectTrack (track) {
-    if (track.type === 'text') {
-        this._player.selectTextTrack(track)
-    } else if (track.type === 'variant') {
-        this._player.selectVariantTrack(track)
-        if (track.mimeType.startsWith('video/')) {
-            // we trigger the adaptation event here
-            // because Shaka doesn't trigger its event on "manual" selection.
-            this._onAdaptation()
-        }
-    } else {
-        throw new Error('Unhandled track type:', track.type);
+  selectTrack (track, clearBuffer) {
+    switch(track.type) {
+    case 'text':
+      this._player.selectTextTrack(track)
+      break
+    case 'variant':
+      this._player.selectVariantTrack(track, clearBuffer)
+      if (track.mimeType.startsWith('video/')) {
+        // we trigger the adaptation event here
+        // because Shaka doesn't trigger its event on "manual" selection.
+        this._onAdaptation()
+      }
+      break
+    default:
+      throw new Error('Unhandled track type:', track.type)
     }
+  }
+
+  selectLanguage(language, role) {
+    this._player.selectAudioLanguage(language, role)
+  }
+
+  get audioLanguages() {
+    return this._player.getAudioLanguages()
   }
 
   /**
@@ -290,7 +301,7 @@ class DashShakaPlayback extends HTML5Video {
   }
 
   _loaded () {
-    this._onShakaReady();
+    this._onShakaReady()
     this._startToSendStats()
     this._fillLevels()
     this._checkForClosedCaptions()


### PR DESCRIPTION

# Fix for Shaka 2.2.x to be able to switch languages

When there is only one track per language, there are no more "variant" type tracks  for audio payload. 
We just get a list of unique languages. Therefore we need to extend the plugin API to be able to select languages that are not "variant". 

Changes:

* add selectLanguage method with a "role" parameter. this can allow to choose between "variants" of one language (if there are any, they can be find in the audioTracks property) 

* improve selectTrack (use switch-case)

* add isAudioOnly implementation to plugin 

* fix lint script calls

* add .editorconfig file








