### PR TITLE
add babelrc file - fixes issues with projects nested as git submodules and different babel presets across there

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,6 @@
+{
+  "presets": ["es2015"],
+  "plugins": [
+    "add-module-exports"
+  ]
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,11 +36,7 @@ const webpackConfig = (config) => {
           loader: 'babel-loader',
           include: [
             path.resolve(__dirname, 'src')
-          ],
-          options: {
-            presets: ['es2015'],
-            plugins: ['add-module-exports'],
-          },
+          ]
         },
       ],
     },


### PR DESCRIPTION
When the project was nested in a directory, babel would look for a babelrc file in the top directory, which was taken precedence over the options in the webpack file.