### PR TITLE
fix: calling HTML5 playback (super) destroy synchronously

### DIFF
--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -252,6 +252,8 @@ class DashShakaPlayback extends HTML5Video {
     } else {
       this._destroy()
     }
+
+    super.destroy()
   }
 
   _setup () {
@@ -338,7 +340,6 @@ class DashShakaPlayback extends HTML5Video {
   }
 
   _destroy () {
-    super.destroy()
     this._isShakaReadyState = false
     Log.debug('shaka was destroyed')
   }


### PR DESCRIPTION
Calling super.destroy only after Shaka Player destroy promise resolve/fail can cause some race conditions bug, like:

When player change the source (using load method), the video tag was recreated, causing a browser error: "play can only be initiated by a user gesture". This can happen because DomRecycler.garbage is called in HTML5Video destroy method, DashShakPlayback will delay this process.
Now, the DomRecycler.garbage and all super.destroy process will be processed synchronously, avoiding this kind of errors.