### PR TITLE
playback error: enhancing error data (add HTML5 Video error object)

### DIFF
--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -308,8 +308,13 @@ class DashShakaPlayback extends HTML5Video {
   }
 
   _onError (err) {
-    Log.error('Shaka error event:', err)
-    this.trigger(Events.PLAYBACK_ERROR, err, this.name)
+    const error = {
+      shakaError: err,
+      videoError: this.el.error
+    }
+
+    Log.error('Shaka error event:', error)
+    this.trigger(Events.PLAYBACK_ERROR, error, this.name)
   }
 
   _onAdaptation () {


### PR DESCRIPTION
`_onError` method can be called by HTML5 video tag erros or Shaka Player internal errors. This change will always return/log all error data available.