### PR TITLE
Add dvr support

### DIFF
--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -447,6 +447,18 @@ class DashShakaPlayback extends HTML5Video {
     })
   }
 
+  _updateSettings() {
+    if (this.getPlaybackType() === 'vod')
+      this.settings.left = ['playpause', 'position', 'duration']
+    else if (this.dvrEnabled)
+      this.settings.left = ['playpause']
+    else
+      this.settings.left = ['playstop']
+
+    this.settings.seekEnabled = this.isSeekEnabled()
+    this.trigger(Events.PLAYBACK_SETTINGSUPDATE)
+  }
+
   _destroy () {
     this._isShakaReadyState = false
     Log.debug('shaka was destroyed')

--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -166,6 +166,7 @@ class DashShakaPlayback extends HTML5Video {
   }
 
   stop () {
+    this._stopTimeUpdateTimer()
     clearInterval(this.sendStatsId)
     this._stopped = true
 
@@ -202,16 +203,16 @@ class DashShakaPlayback extends HTML5Video {
 
   selectTrack (track) {
     if (track.type === 'text') {
-        this._player.selectTextTrack(track)
+      this._player.selectTextTrack(track)
     } else if (track.type === 'variant') {
-        this._player.selectVariantTrack(track)
-        if (track.mimeType.startsWith('video/')) {
-            // we trigger the adaptation event here
-            // because Shaka doesn't trigger its event on "manual" selection.
-            this._onAdaptation()
-        }
+      this._player.selectVariantTrack(track)
+      if (track.mimeType.startsWith('video/')) {
+        // we trigger the adaptation event here
+        // because Shaka doesn't trigger its event on "manual" selection.
+        this._onAdaptation()
+      }
     } else {
-        throw new Error('Unhandled track type:', track.type);
+      throw new Error('Unhandled track type:', track.type)
     }
   }
 
@@ -340,6 +341,8 @@ class DashShakaPlayback extends HTML5Video {
   }
 
   _onTimeUpdate() {
+    if (!this.shakaPlayerInstance) return
+
     let update = {
       current: this.getCurrentTime(),
       total: this.getDuration(),

--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -80,6 +80,10 @@ class DashShakaPlayback extends HTML5Video {
     return this.seekRange.start
   }
 
+  get presentationTimeline() {
+    return this.shakaPlayerInstance.getManifest().presentationTimeline
+  }
+
   constructor (...args) {
     super(...args)
     this._levels = []
@@ -87,6 +91,10 @@ class DashShakaPlayback extends HTML5Video {
     this._isShakaReadyState = false
 
     this._minDvrSize = typeof (this.options.shakaMinimumDvrSize) === 'undefined' ? 60 : this.options.shakaMinimumDvrSize
+  }
+
+  getProgramDateTime() {
+    return new Date((this.presentationTimeline.getPresentationStartTime() + this.seekRange.start) * 1000)
   }
 
   _updateDvr(status) {
@@ -346,7 +354,7 @@ class DashShakaPlayback extends HTML5Video {
     let update = {
       current: this.getCurrentTime(),
       total: this.getDuration(),
-      firstFragDateTime: this.shakaPlayerInstance.getManifest().presentationTimeline.getPresentationStartTime()
+      firstFragDateTime: this.getProgramDateTime()
     }
     let isSame = this._lastTimeUpdate && (
       update.current === this._lastTimeUpdate.current &&


### PR DESCRIPTION
This PR adds initial support for DVR.

It adds the new event triggers to indicate DVR availability and new getters to indicate the duration and the seek range availability of live streaming.