### PR TITLE
Fix - Keep only one timer for timeUpdate

### DIFF
--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -137,13 +137,14 @@ class DashShakaPlayback extends HTML5Video {
   }
 
   _startTimeUpdateTimer() {
+    this._stopTimeUpdateTimer()
     this._timeUpdateTimer = setInterval(() => {
       this._onTimeUpdate()
     }, 100)
   }
 
   _stopTimeUpdateTimer() {
-    clearInterval(this._timeUpdateTimer)
+    this._timeUpdateTimer && clearInterval(this._timeUpdateTimer)
   }
 
   // skipping HTML5Video `_setupSrc` (on tag video)


### PR DESCRIPTION
This PR fixes a leak of time update. 

The problem happens when the `play` is called multiple times, for each time that it is called a new timer was being generated and the old was not being cleared.

To fix the problem we are always removing the old timer before creating a new one.