### PR TITLE
[WIP] fix: trigger playback ready event when rendered

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A [clappr](https://github.com/clappr/clappr) playback to play dash based on the amazing [shaka-player](https://github.com/google/shaka-player).
 
-> CDN JSDELIVR: https://cdn.jsdelivr.net/gh/clappr/dash-shaka-playback@latest/dist/dash-shaka-playback.js
+> CDN JSDELIVR: https://cdn.jsdelivr.net/npm/dash-shaka-playback@latest/dist/dash-shaka-playback.min.js
 >
 > CDNJS: https://cdnjs.cloudflare.com/ajax/libs/dash-shaka-playback/2.0.5/dash-shaka-playback.js
 >
@@ -24,8 +24,8 @@ A [clappr](https://github.com/clappr/clappr) playback to play dash based on the 
 ```html
 <html>
   <head>
-    <script src="https://cdn.jsdelivr.net/gh/clappr/clappr@latest/dist/clappr.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/gh/clappr/dash-shaka-playback@latest/dist/dash-shaka-playback.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/clappr@latest/dist/clappr.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dash-shaka-playback@latest/dist/dash-shaka-playback.min.js"></script>
   </head>
 
   <body>

--- a/public/index.html
+++ b/public/index.html
@@ -44,8 +44,8 @@
             })
         }
     </script>
-    <script src="https://cdn.jsdelivr.net/gh/clappr/clappr@latest/dist/clappr.min.js"></script>
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/clappr@latest/dist/clappr.min.js"></script>
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/level-selector@latest/dist/level-selector.min.js"></script>
     <script type="text/javascript" charset="utf-8" src="./dist/dash-shaka-playback.js"> </script>
-    <script type="text/javascript" src="//cdn.jsdelivr.net/clappr.level-selector/latest/level-selector.min.js"></script>
 </body>
 </html>

--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -401,7 +401,7 @@ class DashShakaPlayback extends HTML5Video {
 
   _fillLevels () {
     if (this._levels.length === 0) {
-      this._levels = this.videoTracks.map((videoTrack) => { return {id: videoTrack.id, label: `${videoTrack.height}p`} }).reverse()
+      this._levels = this.videoTracks.map((videoTrack) => { return {id: videoTrack.id, level: videoTrack, label: `${videoTrack.height}p`} }).reverse()
       this.trigger(Events.PLAYBACK_LEVELS_AVAILABLE, this.levels)
     }
   }

--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -73,7 +73,9 @@ class DashShakaPlayback extends HTML5Video {
   }
 
   getCurrentTime() {
-    return this.shakaPlayerInstance.getMediaElement().currentTime - this.seekRange.start
+    return this.shakaPlayerInstance
+      ? this.shakaPlayerInstance.getMediaElement().currentTime - this.seekRange.start
+      : 0
   }
 
   get _startTime() {
@@ -81,6 +83,8 @@ class DashShakaPlayback extends HTML5Video {
   }
 
   get presentationTimeline() {
+    if (!this.shakaPlayerInstance) return
+
     return this.shakaPlayerInstance.getManifest().presentationTimeline
   }
 
@@ -99,7 +103,11 @@ class DashShakaPlayback extends HTML5Video {
   }
 
   getProgramDateTime() {
-    return new Date((this.presentationTimeline.getPresentationStartTime() + this.seekRange.start) * 1000)
+    let presentationStartTime = this.presentationTimeline
+      ? this.presentationTimeline.getPresentationStartTime()
+      : null
+
+    return new Date((presentationStartTime + this.seekRange.start) * 1000)
   }
 
   _updateDvr(status) {
@@ -155,15 +163,13 @@ class DashShakaPlayback extends HTML5Video {
   // skipping HTML5Video `_setupSrc` (on tag video)
   _setupSrc () {}
 
-  // skipping ready event on video tag in favor of ready on shaka
   _ready () {
-    // override with no-op
+    this.trigger(Events.PLAYBACK_READY, this.name)
   }
 
   _onShakaReady() {
     this._isShakaReadyState = true
     this.trigger(DashShakaPlayback.Events.SHAKA_READY)
-    this.trigger(Events.PLAYBACK_READY, this.name)
   }
 
   get isReady () {

--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -83,9 +83,14 @@ class DashShakaPlayback extends HTML5Video {
   }
 
   get presentationTimeline() {
-    if (!this.shakaPlayerInstance) return
+    // Manifest may equals null (for example, source load failure)
+    let manifest = this.shakaPlayerInstance
+      ? this.shakaPlayerInstance.getManifest()
+      : null
 
-    return this.shakaPlayerInstance.getManifest().presentationTimeline
+    return manifest
+      ? manifest.presentationTimeline
+      : null
   }
 
   get bandwidthEstimate() {

--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -135,7 +135,10 @@ class DashShakaPlayback extends HTML5Video {
 
   play () {
     if (!this._player) {
-      this._setup()
+      // User interaction is lost when Shaka instance load() fetch the manifest
+      // Calling consent() before setup Shaka instance fix this issue (Safari browser on macOS)
+      this.consent()
+      process.nextTick(() => this._setup())
     }
 
     if (!this.isReady) {


### PR DESCRIPTION
It ensure that "PLAYBACK_READY" event is trigger when plugin is rendered to attempt to be consistent with other playback plugins.

These changes allow the "CORE_READY" event to be trigger before the play() method is called.

I also added some conditions to avoid potential predictable exception(s) on undefined/null properties/method results.

Should fix #74.

I focused on avoiding any backward incompatible changes, but it would be nice to have some code review before merge.
