### PR TITLE
Overwrite HTML5Video inherited methods

### DIFF
--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -117,7 +117,7 @@ class DashShakaPlayback extends HTML5Video {
     // assume live if time within 3 seconds of end of stream
     this.dvrEnabled && this._updateDvr(time < this._duration-3)
     time += this._startTime
-    super.seek(time)
+    this.el.currentTime = time
   }
 
   pause() {

--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -121,10 +121,8 @@ class DashShakaPlayback extends HTML5Video {
   }
 
   pause() {
-    super.pause()
-
-    if (this.dvrEnabled)
-      this._updateDvr(true)
+    this.el.pause()
+    this.dvrEnabled && this._updateDvr(true)
   }
 
   play () {


### PR DESCRIPTION
## Summary

This PR updates `seek` and `pause` methods to overwrite `HTML5Video` Class inherits.

## Changes

* Set the current time on video element when the `seek(time)` method is called;
* Call `videoElement.pause` method when `pause` plugin method is called;

## How to test

All changes in this PR should not impact any use of the `DashShakaPlayback`.