### PR TITLE
Enable multiple calls to _setup() method

### DIFF
--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -367,19 +367,26 @@ class DashShakaPlayback extends HTML5Video {
     super.destroy()
   }
 
-  _setup () {
+  _setup() {
     this._isShakaReadyState = false
     this._ccIsSetup = false
-    this._player = this._createPlayer()
-    this._options.shakaConfiguration && this._player.configure(this._options.shakaConfiguration)
-    this._options.shakaOnBeforeLoad && this._options.shakaOnBeforeLoad(this._player)
 
-    let playerLoaded = this._player.load(this._options.src)
-    playerLoaded.then(() => this._loaded())
-      .catch((e) => this._setupError(e))
+    let runAllSteps = () => {
+      this._player = this._createPlayer()
+      this._options.shakaConfiguration && this._player.configure(this._options.shakaConfiguration)
+      this._options.shakaOnBeforeLoad && this._options.shakaOnBeforeLoad(this._player)
+  
+      let playerLoaded = this._player.load(this._options.src)
+      playerLoaded.then(() => this._loaded())
+        .catch((e) => this._setupError(e))
+    }
+
+    this._player
+      ? this._player.destroy().then(() => runAllSteps())
+      : runAllSteps()
   }
 
-  _createPlayer () {
+  _createPlayer() {
     let player = new shaka.Player(this.el)
     player.addEventListener('error', this._onError.bind(this))
     player.addEventListener('adaptation', this._onAdaptation.bind(this))

--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -373,8 +373,7 @@ class DashShakaPlayback extends HTML5Video {
 
     let runAllSteps = () => {
       this._player = this._createPlayer()
-      this._options.shakaConfiguration && this._player.configure(this._options.shakaConfiguration)
-      this._options.shakaOnBeforeLoad && this._options.shakaOnBeforeLoad(this._player)
+      this._setInitialConfig()
   
       let playerLoaded = this._player.load(this._options.src)
       playerLoaded.then(() => this._loaded())
@@ -392,6 +391,11 @@ class DashShakaPlayback extends HTML5Video {
     player.addEventListener('adaptation', this._onAdaptation.bind(this))
     player.addEventListener('buffering', this._handleShakaBufferingEvents.bind(this))
     return player
+  }
+
+  _setInitialConfig() {
+    this._options.shakaConfiguration && this._player.configure(this._options.shakaConfiguration)
+    this._options.shakaOnBeforeLoad && this._options.shakaOnBeforeLoad(this._player)
   }
 
   _onTimeUpdate() {

--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -374,10 +374,7 @@ class DashShakaPlayback extends HTML5Video {
     let runAllSteps = () => {
       this._player = this._createPlayer()
       this._setInitialConfig()
-  
-      let playerLoaded = this._player.load(this._options.src)
-      playerLoaded.then(() => this._loaded())
-        .catch((e) => this._setupError(e))
+      this._loadSource()
     }
 
     this._player
@@ -396,6 +393,12 @@ class DashShakaPlayback extends HTML5Video {
   _setInitialConfig() {
     this._options.shakaConfiguration && this._player.configure(this._options.shakaConfiguration)
     this._options.shakaOnBeforeLoad && this._options.shakaOnBeforeLoad(this._player)
+  }
+
+  _loadSource() {
+    this._player.load(this._options.src)
+      .then(() => this._loaded())
+      .catch((e) => this._setupError(e))
   }
 
   _onTimeUpdate() {


### PR DESCRIPTION
## Summary

Currently, if the `_setup()` is called after the playback is ready/started to play, one error ([code 3015](https://shaka-player-demo.appspot.com/docs/api/shaka.util.Error.html)) occurs when the `setInterval` loop on `_startTimeUpdateTimer` method tries to update the current time of the old shaka-player instance in the time interval between the `_setup` method is called and one new shaka-player instance is created.

This PR guarantees the delete of the old shaka-player instance (if exists) before the creation of the new one.

## Changes

* Extracted code to initial config into one new method (`_setInitialConfig`);
* Extracted code to load source into one new method (`_loadSource`);
* Aggregate steps to avoid code duplication (`runAllSteps`);
* Chained `runAllSteps` call with the `this._player.destroy` promise if `this_player` exists;

## How to test

* Play any media;
* Config one new media;
  * E.g.: `player.core.activePlayback._options.src = 'your-new-media.mpd'`.
* Call `_setup` method;
  * The configured media should be loaded.

## A picture is worth a thousand words

#### Before

https://user-images.githubusercontent.com/5631063/103771444-8406dc00-5006-11eb-9306-68df6071b747.mov

#### After

https://user-images.githubusercontent.com/5631063/103771488-97b24280-5006-11eb-8c59-40775ef77feb.mov
