### PR TITLE
Prevent access of invalid references

### DIFF
--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -87,7 +87,7 @@ class DashShakaPlayback extends HTML5Video {
   }
 
   get presentationTimeline() {
-    if (!this.shakaPlayerInstance) return
+    if (!this.shakaPlayerInstance || !this.shakaPlayerInstance.getManifest()) return null
 
     return this.shakaPlayerInstance.getManifest().presentationTimeline
   }
@@ -107,7 +107,7 @@ class DashShakaPlayback extends HTML5Video {
   }
 
   getProgramDateTime() {
-    if (!this.shakaPlayerInstance) return 0
+    if (!this.shakaPlayerInstance || !this.presentationTimeline) return 0
 
     return new Date((this.presentationTimeline.getPresentationStartTime() + this.seekRange.start) * 1000)
   }


### PR DESCRIPTION
## Summary

Some calls to `this.shakaPlayerInstance.getManifest()` are doing before one valid shaka player instance exists. This PR prevents those access to avoid log noises.

## Changes

* Returns `null` on `presentationTimeline` getter if `this.shakaPlayerInstance.getManifest()` doesn't exists;
* Returns `0` on `getProgramDateTime` method if `this.presentationTimeline` returns invalid value;

## How to test

* Play any media;
* Open `console` tab of your `developers tools`;
  * Should not have any console about access `presentationTimeline` of `null`.

## A picture is worth a thousand words

#### Before

https://user-images.githubusercontent.com/5631063/103773574-0775fc80-500a-11eb-8f80-2481cb30202f.mov

#### After

https://user-images.githubusercontent.com/5631063/103773598-1197fb00-500a-11eb-9739-af2f5243f61c.mov

