### PR TITLE
Replace .getManifest() call

### DIFF
--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -106,6 +106,10 @@ class DashShakaPlayback extends HTML5Video {
     this._minDvrSize = typeof (this.options.shakaMinimumDvrSize) === 'undefined' ? 60 : this.options.shakaMinimumDvrSize
   }
 
+  getProgramDateTime() {
+    return this.presentationStartTimeAsDate
+  }
+
   _updateDvr(status) {
     this.trigger(Events.PLAYBACK_DVR, status)
     this.trigger(Events.PLAYBACK_STATS_ADD, { 'dvr': status })
@@ -401,7 +405,7 @@ class DashShakaPlayback extends HTML5Video {
     let update = {
       current: this.getCurrentTime(),
       total: this.getDuration(),
-      firstFragDateTime: this.presentationStartTimeAsDate
+      firstFragDateTime: this.getProgramDateTime()
     }
     let isSame = this._lastTimeUpdate && (
       update.current === this._lastTimeUpdate.current &&

--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -106,12 +106,6 @@ class DashShakaPlayback extends HTML5Video {
     this._minDvrSize = typeof (this.options.shakaMinimumDvrSize) === 'undefined' ? 60 : this.options.shakaMinimumDvrSize
   }
 
-  getProgramDateTime() {
-    if (!this.shakaPlayerInstance || !this.presentationTimeline) return 0
-
-    return new Date((this.presentationTimeline.getPresentationStartTime() + this.seekRange.start) * 1000)
-  }
-
   _updateDvr(status) {
     this.trigger(Events.PLAYBACK_DVR, status)
     this.trigger(Events.PLAYBACK_STATS_ADD, { 'dvr': status })

--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -86,10 +86,10 @@ class DashShakaPlayback extends HTML5Video {
     return this.seekRange.start
   }
 
-  get presentationTimeline() {
-    if (!this.shakaPlayerInstance || !this.shakaPlayerInstance.getManifest()) return null
+  get presentationStartTimeAsDate() {
+    if (!this.shakaPlayerInstance || !this.shakaPlayerInstance.getPresentationStartTimeAsDate()) return 0
 
-    return this.shakaPlayerInstance.getManifest().presentationTimeline
+    return new Date(this.shakaPlayerInstance.getPresentationStartTimeAsDate().getTime() + this.seekRange.start * 1000)
   }
 
   get bandwidthEstimate() {
@@ -407,7 +407,7 @@ class DashShakaPlayback extends HTML5Video {
     let update = {
       current: this.getCurrentTime(),
       total: this.getDuration(),
-      firstFragDateTime: this.getProgramDateTime()
+      firstFragDateTime: this.presentationStartTimeAsDate
     }
     let isSame = this._lastTimeUpdate && (
       update.current === this._lastTimeUpdate.current &&


### PR DESCRIPTION
## Summary

The `getManifest()` method was [deprecated by Shaka](https://shaka-player-demo.appspot.com/docs/api/tutorial-upgrade-manifest.html) and was generating a ton of warnings at the DevTools console. 

Shaka has a method to access [directly the presentation start time](https://shaka-player-demo.appspot.com/docs/api/shaka.Player.html) (`getPresentationStartTimeAsDate`) and this PR is responsible for it's implementation.

## Changes

* `clappr-dash-shaka-playback.js` - Fix retrieving of presentation start time as a date.

## How to test

* Play any `LIVE` media;
* Check the `_onTimeUpdate` method;
  * The value of `firstFragDateTime` key should be passed correctly and without warnings at the application console. 
  * For `VoD` medias the sended value should be `0`.
  

## A picture is worth a thousand words

#### Before
<img width="1440" alt="Captura de Tela 2021-06-11 às 17 19 38" src="https://user-images.githubusercontent.com/13765802/121746751-b8faeb80-cadc-11eb-8aeb-a982736bc732.png">


#### After
<img width="1440" alt="Captura de Tela 2021-06-11 às 17 22 06" src="https://user-images.githubusercontent.com/13765802/121746778-c3b58080-cadc-11eb-8242-eb426915c242.png">


