### PR TITLE
getCurrentTime – Add fallback value when Media Element is Undefined

### DIFF
--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -78,8 +78,8 @@ class DashShakaPlayback extends HTML5Video {
 
   getCurrentTime() {
     if (!this.shakaPlayerInstance) return 0
-
-    return this.shakaPlayerInstance.getMediaElement().currentTime - this.seekRange.start
+    const shakaMediaElement = this.shakaPlayerInstance.getMediaElement()
+    return shakaMediaElement ? shakaMediaElement.currentTime - this.seekRange.start : 0
   }
 
   get _startTime() {


### PR DESCRIPTION
## Summary

There's currently a faulty scenario in the `getCurrentTime()` method where there's an attempt to retrieve `currentTime` value from an undefined object returned by the current Shaka Player instance's `MediaElement`.

This PR fixes this scenario.