### PR TITLE
Add getters related to Latency information

### DIFF
--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -66,6 +66,16 @@ class DashShakaPlayback extends HTML5Video {
     return this._duration >= this._minDvrSize && this.getPlaybackType() === 'live'
   }
 
+  get latency() {
+    if (!this.shakaPlayerInstance) return 0
+    return this.shakaPlayerInstance.getStats().liveLatency
+  }
+
+  get currentProgramDateTime() {
+    if (!this.shakaPlayerInstance) return null
+    return this.shakaPlayerInstance.getPlayheadTimeAsDate()
+  }
+
   getDuration() {
     return this._duration
   }


### PR DESCRIPTION
## Summary

This PR implements two new getters to `DashShakaPlayback` that retrieve info related to a live video's latency and its current playing date (the Program Date Time value attributed to the ongoing stream fragment).

In order for this to be retrieved, the following PR must also be implemented: https://github.com/clappr/clappr-core/pull/117

