### PR TITLE
Add getFrameRate method to retrieve video frame rate

### DIFF
--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -82,7 +82,7 @@ class DashShakaPlayback extends HTML5Video {
 
   getFrameRate() {
     if (this.videoTracks && this._currentLevelId) {
-      const track = this.videoTracks.filter((t) => t.id === this._currentLevelId)[0]
+      const track = this.videoTracks.find((t) => t.id === this._currentLevelId)
       return track && track.frameRate ? track.frameRate : null
     }
     return null

--- a/src/clappr-dash-shaka-playback.js
+++ b/src/clappr-dash-shaka-playback.js
@@ -80,6 +80,14 @@ class DashShakaPlayback extends HTML5Video {
     return this._duration
   }
 
+  getFrameRate() {
+    if (this.videoTracks && this._currentLevelId) {
+      const track = this.videoTracks.filter((t) => t.id === this._currentLevelId)[0]
+      return track && track.frameRate ? track.frameRate : null
+    }
+    return null
+  }
+
   get _duration() {
     if (!this.shakaPlayerInstance) return 0
 


### PR DESCRIPTION
## Summary

This MR adds a new `getFrameRate` method for HLS.js playback, allowing access to the frame rate value defined in the manifest for the currently selected level.